### PR TITLE
Remove `echo chat` and `leaderboard`

### DIFF
--- a/src/component/navbar/Navbar.jsx
+++ b/src/component/navbar/Navbar.jsx
@@ -21,8 +21,6 @@ export default function NavBar() {
         <li className={styles.li}><Link className={styles.a} to="/home">Home</Link></li>
         <li className={styles.li}><Link className={styles.a} to="/about">About</Link></li>
         <li className={styles.li}><Link className={styles.a} to="/volunteersearch">Volunteer Search</Link></li>
-        <li className={styles.li}><Link className={styles.a} to="/leaderboard">Leader Board</Link></li>
-        <li className={styles.li}><Link className={styles.a} to="/ecochat">Eco Chat</Link></li>
         <li className={styles.li}><Link className={styles.a} to="/aboutthecreators">About The Creators</Link></li>
       </ul>
     </nav>


### PR DESCRIPTION
I officially remove eco chat and leaderboard from the nav-bar.